### PR TITLE
Use docker 1.10 user namespacing

### DIFF
--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -20,11 +20,11 @@
     },
     {
       "type": "shell",
-      "script": "scripts/install-docker.sh"
+      "script": "scripts/install-buildkite.sh"
     },
     {
       "type": "shell",
-      "script": "scripts/install-buildkite.sh"
+      "script": "scripts/install-docker.sh"
     }
   ]
 }

--- a/packer/conf/docker.conf
+++ b/packer/conf/docker.conf
@@ -2,4 +2,4 @@
 # running containers.  The default value of 1048576 mirrors the value
 # used by the systemd service unit.
 DAEMON_MAXFILES=1048576
-OPTIONS="--default-ulimit nofile=1024:4096 -s overlay"
+OPTIONS="--default-ulimit nofile=1024:4096 -s overlay --userns-remap=buildkite-agent"

--- a/packer/conf/subgid
+++ b/packer/conf/subgid
@@ -1,0 +1,1 @@
+buildkite-agent:496:65536

--- a/packer/conf/subuid
+++ b/packer/conf/subuid
@@ -1,0 +1,1 @@
+buildkite-agent:498:65536

--- a/packer/scripts/install-buildkite.sh
+++ b/packer/scripts/install-buildkite.sh
@@ -10,7 +10,6 @@ priority=1
 EOF
 
 sudo yum -y install buildkite-agent
-sudo usermod -a -G docker buildkite-agent
 
 # https://github.com/buildkite/agent/issues/234
 if [ -f /etc/init/buildkite-agent.conf ]; then

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -1,11 +1,19 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
 
 sudo yum update -yq
 sudo yum install -yq docker
 sudo usermod -a -G docker ec2-user
-sudo cp /tmp/conf/docker.conf /etc/sysconfig/docker
+sudo usermod -a -G docker buildkite-agent
 
-sudo service docker start
+sudo cp /tmp/conf/docker.conf /etc/sysconfig/docker
+sudo cp /tmp/conf/subuid /etc/subuid
+sudo cp /tmp/conf/subgid /etc/subgid
+
+# Overwrite the yum packaged docker with the latest
+sudo wget https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 -O /usr/bin/docker
+sudo chmod +x /usr/bin/docker
+
+sudo service docker start || ( cat /var/log/docker && false )
 sudo docker info
 
 # installs docker-compose


### PR DESCRIPTION
Docker 1.10 introduces user namespacing. This allows us to lock down the docker daemon to a non root user account.

This means doing
```
docker run -it -v /:/hostroot busybox touch /hostroot/things-owned-by-root
```
Will no longer be able to modify the host as root.

Apart from being much more secure, it means that files created inside a docker based build script will be owned by buildkite-agent, instead of root. This happens often when projects volume mount the project root into the container.

This is a brand new feature, and there are likely to be bugs. ~~At the very least wait till 1.10.3 for docker/docker#20446 to be fixed.~~

Things that do not work with userns:

Using --privileged mode flag on docker run
 - sharing PID or NET namespaces with the host (--pid=host or --net=host)
 - sharing a network namespace with an existing container (--net=container:other)
 - sharing an IPC namespace with an existing container (--ipc=container:other)
 - A --readonly container filesystem (this is a Linux kernel restriction against remounting with modified flags of a currently mounted filesystem when inside a user namespace)
 - external (volume or graph) drivers which are unaware/incapable of using daemon user mappings