### PR TITLE
Install configurations for N number of buildkite agents per instance

### DIFF
--- a/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
+++ b/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
@@ -1,3 +1,21 @@
 #!/bin/bash
 
-service buildkite-agent stop
+set -eu -o pipefail
+eval "$(cat /var/lib/buildkite-agent/cfn-env)"
+
+echo "Stopping buildkite-agent gracefully"
+
+service buildkite-agent stop &
+
+if [[ ${BUILDKITE_AGENTS_PER_INSTANCE} > 1 ]]; then
+  for i in $(seq 1 $(( ${BUILDKITE_AGENTS_PER_INSTANCE} - 1 )) ); do
+    service "buildkite-agent-${i}" stop &
+  done
+fi
+
+until pgrep buildkite-agent > /dev/null; do
+  echo "Waiting for buildkite-agent processes to finish..."
+  sleep 0.5
+done
+
+echo "buildkite-agent stopped"

--- a/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
+++ b/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
@@ -1,17 +1,15 @@
 #!/bin/bash
 
 set -eu -o pipefail
+
+# Expose BUILDKITE_AGENTS_PER_INSTANCE
 eval "$(cat /var/lib/buildkite-agent/cfn-env)"
 
 echo "Stopping buildkite-agent gracefully"
 
-service buildkite-agent stop &
-
-if [[ ${BUILDKITE_AGENTS_PER_INSTANCE} > 1 ]]; then
-  for i in $(seq 1 $(( ${BUILDKITE_AGENTS_PER_INSTANCE} - 1 )) ); do
-    service "buildkite-agent-${i}" stop &
-  done
-fi
+for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
+  service "buildkite-agent-${i}" stop &
+done
 
 until pgrep buildkite-agent > /dev/null; do
   echo "Waiting for buildkite-agent processes to finish..."

--- a/packer/scripts/install-buildkite-agent.sh
+++ b/packer/scripts/install-buildkite-agent.sh
@@ -62,6 +62,5 @@ echo "Creating plugins dir..."
 sudo mkdir -p /var/lib/buildkite-agent/plugins
 sudo chown -R buildkite-agent: /var/lib/buildkite-agent/plugins
 
-echo "Adding init.d script..."
-sudo cp /tmp/conf/buildkite-agent/init.d/buildkite-agent /etc/init.d/
-sudo chkconfig buildkite-agent on
+echo "Adding init.d template..."
+sudo cp /tmp/conf/buildkite-agent/init.d/buildkite-agent /etc/buildkite-agent/init.d.tmpl

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -73,7 +73,7 @@ Parameters:
     Default: elastic
 
   BuildkiteAgentsPerInstance:
-    Description: How Many Buildkite agents to run per instance/machine
+    Description: The number of Buildkite agents to run on each instance
     Type: Number
     Default: 1
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -340,22 +340,27 @@ Resources:
                   BOOTSTRAP_SCRIPT="buildkite-agent bootstrap"
                 fi;
 
-                for kite in {1..$(BuildkiteAgentsPerInstance)}; do
-                  cat << EOF > /etc/buildkite-agent/buildkite-agent-${kite}.cfg
-                  name="$(AWS::StackName)-${kite}-\$INSTANCE_ID"
-                  token="$(BuildkiteAgentToken)"
-                  meta-data=\$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "$(BuildkiteQueue)" "\$DOCKER_VERSION" "$(AWS::StackName)")
-                  meta-data-ec2=true
-                  bootstrap-script="\$BOOTSTRAP_SCRIPT"
-                  hooks-path=/etc/buildkite-agent/hooks
-                  build-path=/var/lib/buildkite-agent-${kite}/builds
-                  plugins-path=/var/lib/buildkite-agent/plugins
-                  EOF
+                cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
+                name="$(AWS::StackName)-\$INSTANCE_ID-%n"
+                token="$(BuildkiteAgentToken)"
+                meta-data=\$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "$(BuildkiteQueue)" "\$DOCKER_VERSION" "$(AWS::StackName)")
+                meta-data-ec2=true
+                bootstrap-script="\$BOOTSTRAP_SCRIPT"
+                hooks-path=/etc/buildkite-agent/hooks
+                build-path=/var/lib/buildkite-agent/builds
+                plugins-path=/var/lib/buildkite-agent/plugins
+                EOF
 
-                  chown buildkite-agent: /etc/buildkite-agent/buildkite-agent-${kite}.cfg
+                chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
 
-                  service buildkite-agent-${kite} start
-                done
+                if [[ $(BuildkiteAgentsPerInstance) > 1 ]]; then
+                  for i in $(seq 1 $(( $(BuildkiteAgentsPerInstance) - 1 )) ); do
+                    cp /etc/init.d/buildkite-agent /etc/init.d/buildkite-agent-\${i}
+                    service buildkite-agent-\${i} start
+                  done
+                fi;
+
+                service buildkite-agent start
 
             03-fetch-authorized-users:
               test: test -n "$(AuthorizedUsersUrl)"

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -357,7 +357,7 @@ Resources:
                   service buildkite-agent-${kite} start
                 done
 
-            04-fetch-authorized-users:
+            03-fetch-authorized-users:
               test: test -n "$(AuthorizedUsersUrl)"
               command: |
                 #!/bin/bash -eu

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -308,6 +308,7 @@ Resources:
                 cat << EOF > /var/lib/buildkite-agent/cfn-env
                 BUILDKITE_STACK_NAME=$(AWS::StackName)
                 BUILDKITE_SECRETS_BUCKET=$(SecretsBucket)
+                BUILDKITE_AGENTS_PER_INSTANCE=$(BuildkiteAgentsPerInstance)
                 EOF
 
                 chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
@@ -354,7 +355,7 @@ Resources:
                 chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
 
                 if [[ $(BuildkiteAgentsPerInstance) > 1 ]]; then
-                  for i in $(seq 1 $(( $(BuildkiteAgentsPerInstance) - 1 )) ); do
+                  for i in \$(seq 1 \$(( $(BuildkiteAgentsPerInstance) - 1 )) ); do
                     cp /etc/init.d/buildkite-agent /etc/init.d/buildkite-agent-\${i}
                     service buildkite-agent-\${i} start
                   done

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -11,6 +11,7 @@ Metadata:
         - BuildkiteOrgSlug
         - BuildkiteQueue
         - BuildkiteApiAccessToken
+        - BuildkiteAgentsPerInstance
 
       - Label:
           default: Network Configuration
@@ -70,6 +71,11 @@ Parameters:
     Description: Name of the Buildkite agent queue that agents will use
     Type: String
     Default: elastic
+
+  BuildkiteAgentsPerInstance:
+    Description: How Many Buildkite agents to run per instance/machine
+    Type: Number
+    Default: 1
 
   SecretsBucket:
     Description: Optional - name of an S3 bucket containing provisioning files
@@ -334,21 +340,24 @@ Resources:
                   BOOTSTRAP_SCRIPT="buildkite-agent bootstrap"
                 fi;
 
-                cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
-                name="$(AWS::StackName)-\$INSTANCE_ID"
-                token="$(BuildkiteAgentToken)"
-                meta-data=\$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "$(BuildkiteQueue)" "\$DOCKER_VERSION" "$(AWS::StackName)")
-                meta-data-ec2=true
-                bootstrap-script="\$BOOTSTRAP_SCRIPT"
-                hooks-path=/etc/buildkite-agent/hooks
-                build-path=/var/lib/buildkite-agent/builds
-                plugins-path=/var/lib/buildkite-agent/plugins
-                EOF
+                for kite in {1..$(BuildkiteAgentsPerInstance)}; do
+                  cat << EOF > /etc/buildkite-agent/buildkite-agent-${kite}.cfg
+                  name="$(AWS::StackName)-${kite}-\$INSTANCE_ID"
+                  token="$(BuildkiteAgentToken)"
+                  meta-data=\$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "$(BuildkiteQueue)" "\$DOCKER_VERSION" "$(AWS::StackName)")
+                  meta-data-ec2=true
+                  bootstrap-script="\$BOOTSTRAP_SCRIPT"
+                  hooks-path=/etc/buildkite-agent/hooks
+                  build-path=/var/lib/buildkite-agent-${kite}/builds
+                  plugins-path=/var/lib/buildkite-agent/plugins
+                  EOF
 
-                chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
+                  chown buildkite-agent: /etc/buildkite-agent/buildkite-agent-${kite}.cfg
 
-                service buildkite-agent start
-            03-fetch-authorized-users:
+                  service buildkite-agent-${kite} start
+                done
+
+            04-fetch-authorized-users:
               test: test -n "$(AuthorizedUsersUrl)"
               command: |
                 #!/bin/bash -eu

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -354,15 +354,11 @@ Resources:
 
                 chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
 
-                if [[ $(BuildkiteAgentsPerInstance) > 1 ]]; then
-                  for i in \$(seq 1 \$(( $(BuildkiteAgentsPerInstance) - 1 )) ); do
-                    cp /etc/init.d/buildkite-agent /etc/init.d/buildkite-agent-\${i}
-                    service buildkite-agent-\${i} start
-                    chkconfig --add buildkite-agent\${i}
-                  done
-                fi;
-
-                service buildkite-agent start
+                for i in \$(seq 1 $(BuildkiteAgentsPerInstance)); do
+                  cp /etc/buildkite-agent/init.d.tmpl /etc/init.d/buildkite-agent-\${i}
+                  service buildkite-agent-\${i} start
+                  chkconfig --add buildkite-agent-\${i}
+                done
 
             03-fetch-authorized-users:
               test: test -n "$(AuthorizedUsersUrl)"

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -358,6 +358,7 @@ Resources:
                   for i in \$(seq 1 \$(( $(BuildkiteAgentsPerInstance) - 1 )) ); do
                     cp /etc/init.d/buildkite-agent /etc/init.d/buildkite-agent-\${i}
                     service buildkite-agent-\${i} start
+                    chkconfig --add buildkite-agent\${i}
                   done
                 fi;
 


### PR DESCRIPTION
This patch adds in the ability to configure multiple buildkite-agents per EC2 instance. 

This is a configuration I've seen at 3 different companies now, although in those cases, they've either been manually configured, or taken something like the CF stack and then modified post-deployment.

Some people want to get better utilization of the hardware they are running BK on, especially in the case where bigger instances are often multi-core, but their builds may be single-threaded.

Was going to keep this addition as an 'internal' fork, but following on from discussion/help from @toolmantim on Slack, have made a PR.