### PR TITLE
Update Amazon Linux and Docker

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -86,17 +86,19 @@ Mappings:
     us-east-1 : { AMI: $base_image_id }
 EOF
 
-  for region in ${DESTINATION_REGIONS[*]} ; do
-    echo "--- Copying $image_id to $region"
+  if [[ $BUILDKITE_BRANCH == "master" ]] ; then
+    for region in ${DESTINATION_REGIONS[*]} ; do
+      echo "--- Copying $image_id to $region"
 
-    copied_image_id=$(copy_ami_to_region "$base_image_id" us-east-1 "$region" "$image_name-$region")
+      copied_image_id=$(copy_ami_to_region "$base_image_id" us-east-1 "$region" "$image_name-$region")
 
-    wait_for_ami_to_be_available "$copied_image_id" "$region"
+      wait_for_ami_to_be_available "$copied_image_id" "$region"
 
-    make_ami_public "$copied_image_id" "$region"
+      make_ami_public "$copied_image_id" "$region"
 
-    echo "    $region : { AMI: $copied_image_id }" >> "$destination_yml"
-  done
+      echo "    $region : { AMI: $copied_image_id }" >> "$destination_yml"
+    done
+  fi
 }
 
 generate_mappings() {

--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -3,7 +3,7 @@
     {
       "type": "amazon-ebs",
       "region": "us-east-1",
-      "source_ami": "ami-08111162",
+      "source_ami": "ami-6869aa05",
       "region": "us-east-1",
       "instance_type": "c4.large",
       "ssh_username": "ec2-user",

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -2,8 +2,8 @@
 
 set -eu -o pipefail
 
-DOCKER_VERSION=1.11.1
-DOCKER_SHA256=893e3c6e89c0cd2c5f1e51ea41bc2dd97f5e791fcfa3cee28445df277836339d
+DOCKER_VERSION=1.11.2
+DOCKER_SHA256=8c2e0c35e3cda11706f54b2d46c2521a6e9026a7b13c7d4b8ae1f3a706fc55e1
 
 sudo yum update -y -q
 sudo yum install -y -q docker

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -9,6 +9,7 @@ sudo yum update -y -q
 sudo yum install -y -q docker
 sudo usermod -a -G docker ec2-user
 sudo cp /tmp/conf/docker/docker.conf /etc/sysconfig/docker
+sudo service docker stop
 
 # Overwrite the yum packaged docker with the latest
 # Releases can be found at https://github.com/docker/docker/releases


### PR DESCRIPTION
Updates Amazon Linux from 2016.03.1 https://aws.amazon.com/amazon-linux-ami/2016.03-release-notes/

Updates Docker from 1.11.1 to 1.11.2 https://github.com/docker/docker/releases/tag/v1.11.2