### PR TITLE
Remove 'github' from the secrets bucket SSH key name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 A simple to setup, best-practice, auto-scaling build cluster running in your own AWS VPC.
 
-This stack is designed to run almost all of your organization’s projects, whether it’s legacy backend application’s tests parallelized across dozens or hundreds of agents for faster build times, or running ops-related tasks with your own tools or the `aws-cli`.
+This stack is designed to run almost all of your organization’s projects, whether it’s legacy backend application tests parallelized across dozens or hundreds of agents for faster build times, or running ops-related tasks with your own tools or the `aws-cli`, you can run them all on this single stack.
 
 * All major AWS regions
 * Configurable instance size
 * Configurable number of agents per instance
 * Configurable spot instance bid price
-* Custom scale-in/scale-in parameters
+* Configurable auto-scaling based on build activity
 * Docker and Docker Compose support
 * Per-pipeline S3 secret storage (with SSE encryption support)
 * Docker Registry push/pull support

--- a/README.md
+++ b/README.md
@@ -2,20 +2,21 @@
 
 [![Build status](https://badge.buildkite.com/d178ab942e2f606a83e79847704648437d82a9c5fdb434b7ae.svg?branch=master)](https://buildkite.com/buildkite-aws-stack/buildkite-aws-stack)
 
-A simple to setup auto-scaling build cluster running in your own AWS VPC. This single stack gives you a build cluster that all your projects can use, and allows you to massively parallelise any project that can be run with Docker Compose.
+A simple to setup, best-practice, auto-scaling build cluster running in your own AWS VPC.
+
+This stack is designed to run almost all of your organization’s projects, whether it’s legacy backend application’s tests parallelized across dozens or hundreds of agents for faster build times, or running ops-related tasks with your own tools or the `aws-cli`.
 
 * All major AWS regions
-* Use stable, unstable or experimental Buildkite Agent releases
-* Choose any instance size you need
+* Configurable instance size
 * Configurable number of agents per instance
-* Configurable scale-in/scale-in parameters
-* Docker, Docker Compose and docker-gc
-* Per-pipeline S3 secret storage (with encryption) for SSH keys and environment hooks
-* Docker Hub credential login support for pushing images
-* CloudWatch system and buildkite agent logs
-* CloudWatch build metrics
-* Spot instance pricing
-* Test new build clusters by easily spinning up new instances of the stack
+* Configurable spot instance bid price
+* Custom scale-in/scale-in parameters
+* Docker and Docker Compose support
+* Per-pipeline S3 secret storage (with SSE encryption support)
+* Docker Registry push/pull support
+* CloudWatch logs for system and buildkite agent events
+* CloudWatch metrics from the Buildkite API
+* Support for stable, unstable or experimental Buildkite Agent releases
 
 ## Getting Started
 
@@ -58,9 +59,9 @@ AWS_PROFILE="SOMETHING" make create-stack
 * [jq](https://stedolan.github.io/jq/) - useful for manipulating JSON responses from cli tools such as aws-cli
 * [docker-gc](https://github.com/spotify/docker-gc) - removes old docker images
 
-## Running Builds on Your Stack
+## Targetting your Stack’s Agents
 
-When you create the stack you specify a `BuildkiteQueue` parameter which is used to set agent’s queue, and ensures they will only accept jobs that are specifically designed for it. This means you can easily experiment with entire new stacks without interuppting existing builds. See the [Agent Queues documentation](https://buildkite.com/docs/agent/queues) for how to target the agents in your pipelines.
+When you create the stack you specify a `BuildkiteQueue` parameter which is used to set agent’s queue, and ensures they will only accept jobs that specifically target them. This means you can easily experiment with entire new stacks without interuppting existing builds. See the [Agent Queues documentation](https://buildkite.com/docs/agent/queues) for how to target the agents in your pipelines.
 
 Note that if you’ve set `MinInstances` to 0 then you won’t see any agents in Buildkite until you create build jobs, causing the autoscaling metrics to trigger a scale out event.
 
@@ -109,11 +110,13 @@ unset PASSPHRASE
 rm id_rsa_buildkite*
 ```
 
-## Docker Hub Login Support
+## Docker Registry Support
 
 If you want to push or pull from Docker Hub you can use the `env` file in your secrets bucket to export `DOCKER_HUB_USER`, `DOCKER_HUB_PASSWORD` and `DOCKER_HUB_EMAIL`. This will perform a `docker login` before each pipeline step is run, allowing you to `docker push` to Docker Hub.
 
-If you want to use ECR instead of Docker Hub there's no need to worry about credentials, you simply ensure that your agent machines have the necessary IAM roles and permissions.
+If you want to use [AWS ECR](https://aws.amazon.com/ecr/) instead of Docker Hub there's no need to worry about credentials, you simply ensure that your agent machines have the necessary IAM roles and permissions.
+
+For all other services you’ll need to perform your own `docker login` commands using the `env` hook.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ A simple to setup auto-scaling build cluster running in your own AWS VPC. This s
 * Spot instance pricing
 * Test new build clusters by easily spinning up new instances of the stack
 
-Although the stack is completely self-contained, and will create it's own VPC by default, we highly recommend following best practice by setting up a separate development AWS account and using role switching and consolidated billing—see the [Delegate Access Across AWS Accounts tutorial](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) for more information.
-
 ## Getting Started
 
 The easiest way is to launch the latest built version via this button:
 
 [![Launch Buildkite AWS Stack](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/images/cloudformation-launch-stack-button.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=buildkite&templateURL=https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json)
+
+> Although the stack will create it's own VPC by default, we highly recommend following best practice by setting up a separate development AWS account and using role switching and consolidated billing—see the [Delegate Access Across AWS Accounts tutorial](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) for more information.
 
 If you'd like to use the CLI, download [`config.json.example`](config.json.example) to `config.json` and then run the below command to create a new stack.
 
@@ -49,22 +49,50 @@ make create-stack
 AWS_PROFILE="SOMETHING" make create-stack
 ```
 
-## Targeting Builds
+## What’s On Each Machine?
 
-Set your [Agent Query Rules](https://buildkite.com/docs/agent/agent-meta-data) to the `BuildkiteQueue` parameter you provided to your stack (e.g. `queue=elastic`)
+* [Amazon Linux](https://aws.amazon.com/amazon-linux-ami/)
+* [Docker](https://www.docker.com)
+* [Docker Compose](https://docs.docker.com/compose/)
+* [aws-cli](https://aws.amazon.com/cli/) - useful for performing any ops-related tasks
+* [jq](https://stedolan.github.io/jq/) - useful for manipulating JSON responses from cli tools such as aws-cli
+* [docker-gc](https://github.com/spotify/docker-gc) - removes old docker images
 
-## Secrets
+## Running Builds on Your Stack
 
-Your stack has access to the `SecretsBucket` parameter you passed in. This should be used in combination with server-side object encryption to ensure that your CI secrets (such as Github credentials) are reasonably secure. See the [Security](#security) section for more details.
+When you create the stack you specify a `BuildkiteQueue` parameter which is used to set agent’s queue, and ensures they will only accept jobs that are specifically designed for it. This means you can easily experiment with entire new stacks without interuppting existing builds. See the [Agent Queues documentation](https://buildkite.com/docs/agent/queues) for how to target the agents in your pipelines.
 
-You should encrypt your S3 objects with a pipeline-specific key using the environment variable `BUILDKITE_SECRETS_KEY` — you can add that to the Buildkite web UI under the pipeline’s settings. Any key found in `BUILDKITE_SECRETS_KEY` will be used to decrypt files from the secrets bucket.
+Note that if you’ve set `MinInstances` to 0 then you won’t see any agents in Buildkite until you create build jobs, causing the autoscaling metrics to trigger a scale out event.
 
-The secrets bucket should the following layout:
+## Autoscaling
 
-* `/{PipelineSlug}/env` - A bash script agent environment hook
-* `/{PipelineSlug}/id_rsa` - A private key to use for Git SSH operations
+If you provided a `BuildkiteApiAccessToken` your build agents will autoscale. Autoscaling is designed to scale up quite quickly and then gradually scale down. See [the autoscale.yml template](templates/autoscale.yml) for more details, or the [Buildkite Metrics Publisher](https://github.com/buildkite/buildkite-cloudwatch-metrics-publisher) project for how metrics are collected. When scaling down, instances wait until any running jobs on them have completed (thanks to [lifecycled](https://github.com/lox/lifecycled)).
 
-Here’s step-by-step instructions for adding a new encrypted SSH key to your S3 secrets bucket for a new Buildkite pipeline:
+## Pipeline Configuration Environment Variables
+
+The following environment variables can be set on the Buildkite pipeline or step to customize the behaviour of the stack:
+
+* `BUILDKITE_SECRETS_BUCKET` - the name of the S3 bucket where secrets are stored. Default: the value set in the stack parameter when the stack was created. Example: `my-secrets-bucket`
+* `BUILDKITE_SECRETS_KEY` - the encryption key used to decrypt objects from the secrets bucket. Default: nil. Example: `w2Uzhc4kXXbW//T9zaY3neoCbR9roQ10`
+* `BUILDKITE_SECRETS_PREFIX` - the folder within the secrets bucket. Default: the build pipeline's slug. Example: `my-great-pipeline`
+* `SSH_KEY_NAME` - the filename of the SSH key inside this pipeline’s folder in the secrets bucket. Default: `id_rsa`. Example: `id_rsa_github`
+* `SHARED_SSH_KEY_NAME` - the filename of the SSH key in the root of the secrets bucket if there's no pipeline-specific SSH key present. Default: `id_rsa`. Example: `id_rsa_github_shared`
+
+## Secrets Bucket Support
+
+The stack has a `SecretsBucket` parameter which will allow your build agents to automatically get access to SSH private keys and environment hooks for exposing environment variables to builds. The stack doesn't create the bucket for you, you need to do this yourself, but it does create a role that gives read access to the build machines. 
+
+The secrets bucket can contain the following files:
+
+* `/id_sra` - An optional private key to use Git SSH operations when there is no pipeline-specific key present
+* `/{PipelineSlug}/env` - An optional bash script to use as an [agent environment hook](https://buildkite.com/docs/agent/hooks)
+* `/{PipelineSlug}/id_rsa` - An optional pipeline-specific private key to use for Git SSH operations
+
+The files in your secrets bucket should be encrypted with server-side object encryption to ensure they are reasonably secure. See the [Security](#security) section for more details.
+
+Encryption is done via the `BUILDKITE_SECRETS_KEY` environment variable set via the Buildkite pipeline settings, and can be the same, or different, for each pipeline.
+
+Here’s an an example (for OS X) that shows how to create a new private SSH key, generate and copy a random passphrase for S3 encryption, and upload an encypted version of the key to your S3 bucket:
 
 ```bash
 # generate a deploy key for your project
@@ -72,7 +100,7 @@ ssh-keygen -t rsa -b 4096 -f id_rsa_buildkite
 pbcopy < id_rsa_buildkite.pub # paste this into your github deploy key
 
 # upload the private key, encrypted
-PASSPHRASE=$(head -c 24  /dev/urandom | base64)
+PASSPHRASE=$(head -c 24 /dev/urandom | base64)
 aws s3 cp --acl private --sse-c --sse-c-key "$PASSPHRASE" id_rsa_buildkite "s3://{SecretsBucket}/{PipelineSlug}/id_rsa"
 pbcopy <<< "$PASSPHRASE" # paste passphrase into buildkite env as BUILDKITE_SECRETS_KEY
 
@@ -81,11 +109,11 @@ unset PASSPHRASE
 rm id_rsa_buildkite*
 ```
 
-If you want to push or pull from Docker Hub you can use the `env` file and to export `DOCKER_HUB_USER`, `DOCKER_HUB_PASSWORD` and `DOCKER_HUB_EMAIL`.
+## Docker Hub Login Support
 
-## Autoscaling
+If you want to push or pull from Docker Hub you can use the `env` file in your secrets bucket to export `DOCKER_HUB_USER`, `DOCKER_HUB_PASSWORD` and `DOCKER_HUB_EMAIL`. This will perform a `docker login` before each pipeline step is run, allowing you to `docker push` to Docker Hub.
 
-If you provided a `BuildkiteApiAccessToken` your build agents will autoscale. Autoscaling is designed to scale up quite quickly and then gradually scale down. See [the autoscale.yml template](templates/autoscale.yml) for more details, or the [Buildkite Metrics Publisher](https://github.com/buildkite/buildkite-cloudwatch-metrics-publisher) project for how metrics are collected. When scaling down, instances wait until any running jobs on them have completed (thanks to [lifecycled](https://github.com/lox/lifecycled)).
+If you want to use ECR instead of Docker Hub there's no need to worry about credentials, you simply ensure that your agent machines have the necessary IAM roles and permissions.
 
 ## Security
 

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -23,7 +23,7 @@ eval "$(ssh-agent -s)"
 
 if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
 
-  # allow env to override paths
+  # Allow environment vars set in Buildkite to override paths
   secrets_prefix="${BUILDKITE_SECRETS_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
   secrets_url_base="s3://${BUILDKITE_SECRETS_BUCKET}/${secrets_prefix}"
   ssh_key_url="${secrets_url_base}/${SSH_KEY_NAME:-id_rsa}"

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -27,13 +27,17 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   secrets_prefix="${BUILDKITE_SECRETS_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
   secrets_url_base="s3://${BUILDKITE_SECRETS_BUCKET}/${secrets_prefix}"
   ssh_key_url="${secrets_url_base}/${SSH_KEY_NAME:-id_rsa}"
+  old_ssh_key_url="${secrets_url_base}/id_rsa_github"
   env_url="${secrets_url_base}/env"
 
   if s3_exists "$ssh_key_url" ; then
     echo "Downloading ssh key from $ssh_key_url"
     ssh-add <(s3_download "$ssh_key_url")
+  elif s3_exists "$old_ssh_key_url" ; then
+    echo "Downloading ssh key from $old_ssh_key_url"
+    ssh-add <(s3_download "$old_ssh_key_url")
   else
-    echo "No SSH key found at $ssh_key_url"
+    echo "No SSH keys found in s3://${BUILDKITE_SECRETS_BUCKET}"
   fi
 
   if s3_exists "$env_url" ; then

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -28,6 +28,7 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   secrets_url_base="s3://${BUILDKITE_SECRETS_BUCKET}/${secrets_prefix}"
   ssh_key_url="${secrets_url_base}/${SSH_KEY_NAME:-id_rsa}"
   old_ssh_key_url="${secrets_url_base}/id_rsa_github"
+  shared_ssh_key_url="s3://${BUILDKITE_SECRETS_BUCKET}/${SHARED_SSH_KEY_NAME:-id_rsa}"
   env_url="${secrets_url_base}/env"
 
   if s3_exists "$ssh_key_url" ; then
@@ -36,6 +37,9 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   elif s3_exists "$old_ssh_key_url" ; then
     echo "Downloading ssh key from $old_ssh_key_url"
     ssh-add <(s3_download "$old_ssh_key_url")
+  elif s3_exists "$shared_ssh_key_url" ; then
+    echo "Downloading ssh key from $shared_ssh_key_url"
+    ssh-add <(s3_download "$shared_ssh_key_url")
   else
     echo "No SSH keys found in s3://${BUILDKITE_SECRETS_BUCKET}"
   fi

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -3,7 +3,12 @@
 set -eu -o pipefail
 
 s3_exists() {
-  env -i aws s3 ls "$1" --summarize --human-readable
+  env -i aws s3 ls "$1" --summarize --human-readable | \
+    # `s3 ls` does wildcard matching, so `id_rsa` matches `id_rsa_github`, e.g.:
+    # 2016-03-01 17:40:53    1.6 KiB id_rsa_github
+    #
+    # So we need to grep the output for an exact filename match
+    grep "$(basename "$1")\$"
 }
 
 s3_download() {

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -4,8 +4,8 @@ set -eu -o pipefail
 
 s3_exists() {
   env -i aws s3 ls "$1" --summarize --human-readable | \
-    # `s3 ls` does wildcard matching, so `id_rsa` matches `id_rsa_github`, e.g.:
-    # 2016-03-01 17:40:53    1.6 KiB id_rsa_github
+    # `s3 ls` does wildcard matching, so `private_ssh_key` matches `private_ssh_key_old`, e.g.:
+    # 2016-03-01 17:40:53    1.6 KiB private_ssh_key_old
     #
     # So we need to grep the output for an exact filename match
     grep "$(basename "$1")\$"
@@ -31,17 +31,17 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   # Allow environment vars set in Buildkite to override paths
   secrets_prefix="${BUILDKITE_SECRETS_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
   secrets_url_base="s3://${BUILDKITE_SECRETS_BUCKET}/${secrets_prefix}"
-  ssh_key_url="${secrets_url_base}/${SSH_KEY_NAME:-id_rsa}"
-  old_ssh_key_url="${secrets_url_base}/id_rsa_github"
-  shared_ssh_key_url="s3://${BUILDKITE_SECRETS_BUCKET}/${SHARED_SSH_KEY_NAME:-id_rsa}"
+  ssh_key_url="${secrets_url_base}/${SSH_KEY_NAME:-private_ssh_key}"
+  legacy_ssh_key_url="${secrets_url_base}/id_rsa_github"
+  shared_ssh_key_url="s3://${BUILDKITE_SECRETS_BUCKET}/${SHARED_SSH_KEY_NAME:-private_ssh_key}"
   env_url="${secrets_url_base}/env"
 
   if s3_exists "$ssh_key_url" ; then
     echo "Downloading ssh key from $ssh_key_url"
     ssh-add <(s3_download "$ssh_key_url")
-  elif s3_exists "$old_ssh_key_url" ; then
-    echo "Downloading ssh key from $old_ssh_key_url"
-    ssh-add <(s3_download "$old_ssh_key_url")
+  elif s3_exists "$legacy_ssh_key_url" ; then
+    echo "Downloading ssh key from $legacy_ssh_key_url"
+    ssh-add <(s3_download "$legacy_ssh_key_url")
   elif s3_exists "$shared_ssh_key_url" ; then
     echo "Downloading ssh key from $shared_ssh_key_url"
     ssh-add <(s3_download "$shared_ssh_key_url")

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -26,7 +26,7 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   # allow env to override paths
   secrets_prefix="${BUILDKITE_SECRETS_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
   secrets_url_base="s3://${BUILDKITE_SECRETS_BUCKET}/${secrets_prefix}"
-  ssh_key_url="${secrets_url_base}/${SSH_KEY_NAME:-id_rsa_github}"
+  ssh_key_url="${secrets_url_base}/${SSH_KEY_NAME:-id_rsa}"
   env_url="${secrets_url_base}/env"
 
   if s3_exists "$ssh_key_url" ; then


### PR DESCRIPTION
There's nothing Github specific about this key at all, so let's not include it in the name