### PR TITLE
Fix agent log capturing for n agents

### DIFF
--- a/packer/conf/awslogs/awslogs.conf
+++ b/packer/conf/awslogs/awslogs.conf
@@ -6,9 +6,3 @@ file = /var/log/messages
 log_group_name = /var/log/messages
 log_stream_name = {instance_id}
 datetime_format = %b %d %H:%M:%S
-
-[/var/log/buildkite-agent.log]
-file = /var/log/buildkite-agent.log
-log_group_name = /var/log/buildkite-agent.log
-log_stream_name = {instance_id}
-datetime_format = %Y-%m-%d %H:%M:%S

--- a/packer/scripts/install-buildkite-agent.sh
+++ b/packer/scripts/install-buildkite-agent.sh
@@ -42,9 +42,6 @@ echo "Adding sudoers config..."
 sudo cp /tmp/conf/buildkite-agent/sudoers.conf /etc/sudoers.d/buildkite-agent
 sudo chmod 440 /etc/sudoers.d/buildkite-agent
 
-echo "Creating buildkite-agent log..."
-sudo touch /var/log/buildkite-agent.log
-
 echo "Creating hooks dir..."
 sudo mkdir -p /etc/buildkite-agent/hooks
 sudo chown -R buildkite-agent: /etc/buildkite-agent/hooks

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -329,7 +329,11 @@ Resources:
               command: |
                 #!/bin/bash -eu
 
+                # Choose the right binary
+
                 ln -s /usr/bin/buildkite-agent-$(BuildkiteAgentRelease) /usr/bin/buildkite-agent
+
+                # Setup the buildkite-agent config
 
                 INSTANCE_ID=\$(/opt/aws/bin/ec2-metadata --instance-id | cut -d " " -f 2)
                 DOCKER_VERSION=\$(docker --version | cut -f3 -d' ' | sed 's/,//')
@@ -353,6 +357,26 @@ Resources:
                 EOF
 
                 chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
+
+                # Setup logging first so we capture everything
+
+                mkdir -p /var/awslogs/etc/config/
+
+                for i in \$(seq 1 $(BuildkiteAgentsPerInstance)); do
+                  touch /var/log/buildkite-agent-\${i}.log
+
+                  cat << EOF > /var/awslogs/etc/config/buildkite-agent-\${i}
+                [/var/log/buildkite-agent-\${i}.log]
+                file = /var/log/buildkite-agent-\${i}.log
+                log_group_name = /var/log/buildkite-agent.log
+                log_stream_name = {instance_id}-\${i}
+                datetime_format = %Y-%m-%d %H:%M:%S
+                EOF
+                done
+
+                service awslogs restart
+
+                # Setup and start services
 
                 for i in \$(seq 1 $(BuildkiteAgentsPerInstance)); do
                   cp /etc/buildkite-agent/init.d.tmpl /etc/init.d/buildkite-agent-\${i}


### PR DESCRIPTION
In #76 we broke CloudWatch buildkite-agent logs. This fixes them again.