### PR TITLE
Only docker-gc images older than 7 days

### DIFF
--- a/packer/conf/docker/cron.daily/docker-gc
+++ b/packer/conf/docker/cron.daily/docker-gc
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# For parameters, see:
+# https://github.com/spotify/docker-gc
+
+# Remove images older than 7 days (60*60*24*7)
+export GRACE_PERIOD_SECONDS=604800
+
+# This makes sure to remove images even if they've been pushed to an external
+# registry (Docker doesn't remove these by default)
+export FORCE_IMAGE_REMOVAL=1
+
+/usr/bin/docker-gc

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -29,8 +29,11 @@ docker-compose --version
 
 echo "Downloading docker-gc..."
 curl -Lsf https://raw.githubusercontent.com/spotify/docker-gc/master/docker-gc > docker-gc
-sudo mv docker-gc /etc/cron.hourly/docker-gc
-sudo chmod +x /etc/cron.hourly/docker-gc
+sudo mv docker-gc /usr/bin/docker-gc
+
+echo "Adding docker-gc cron task..."
+sudo cp /tmp/conf/docker/cron.daily/docker-gc /etc/cron.daily/docker-gc
+sudo chmod +x /etc/cron.daily/docker-gc
 
 echo "Downloading jq..."
 sudo curl -Lsf -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64


### PR DESCRIPTION
Only clean up docker images once a week.

Closes #78 